### PR TITLE
chore: only build Book once with `make serve`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ check : .check.tstamp
 	@find deploy -name node_modules \
 	    || (echo "deploy/ should not include node_modules"; false)
 
-serve : book
+serve : $(GITBOOK_DEPS)
 	"${ROOT_DIR}"/node_modules/.bin/gitbook serve
 
 serve_static_files : book

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   },
   "private": true,
   "scripts": {
-    "start": "make serve",
-    "postinstall": "make book"
+    "start": "make serve"
   }
 }


### PR DESCRIPTION
Currently `make serve` can end up building the book as many as three
times before serving (depending on if dependencies are installed).

This commit removes the `postinstall` hook call to `make book` and
also changes `make serve` to no longer depend on `make book`. Instead
`make serve` will now rely on `$(GITBOOK_DEPS)` to ensure dependencies
are installed and rely on `gitbook serve` to do the build.

AFAICT all functionality is maintained and the compilation time for
first run is significantly improved.